### PR TITLE
Fix problem where object Content-Type was not being set correctly in S3.

### DIFF
--- a/md5s3stash.py
+++ b/md5s3stash.py
@@ -216,8 +216,10 @@ def s3move(place1, place2, mime, s3):
         l.debug('bucket created')
     if not(bucket.get_key(parts.path)):
         key = bucket.new_key(parts.path)
-        key.set_contents_from_filename(place1)
+        # metadata has to be set before setting contents/creating object. 
+        # See https://gist.github.com/garnaat/1791086
         key.set_metadata("Content-Type", mime)
+        key.set_contents_from_filename(place1)
         # key.set_acl('public-read')
         l.debug('file sent to s3')
     else:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name='md5s3stash',
     description='content addressable storage in AWS S3',
     long_description=read('README.md'),
-    version='0.2.1',
+    version='0.2.2',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Turns out that you have to key.set_metadata before doing key.set_contents_from_filename
Once the object has been loaded into s3, you have to actually copy the object onto itself with new metadata in order to update it.
See  https://gist.github.com/garnaat/1791086