### PR TITLE
Tests for header sending and redis tied dictionary as cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,7 @@ The test code has an example of using redis-collections as the caching dictionar
 
 To run a test of redis integration with the caching mechanism, set the environment variable LIVE_REDIS_TEST and have a redis server running locally.
 
+Local redis with docker:
+
+docker pull redis
+docker run -p 6379:6379 --name md5-test -d redis

--- a/README.md
+++ b/README.md
@@ -121,3 +121,14 @@ site-packages/tornado/log.py options:
 The `bucket_base` parameter, command line arguments `-b` and `--bucket_base`, and environmental variable `BUCKET_BASE`
 must be unique name in all of AWS S3.  The IAM role or user will need to be able to create/write/read to 36 buckets
 (`0-9a-z.BUCKET_BASE`).
+
+## Development
+
+md5s3stash has been tested on python 2.6 & 2.7.
+
+python setup.py test
+
+The test code has an example of using redis-collections as the caching dictionary.
+
+To run a test of redis integration with the caching mechanism, set the environment variable LIVE_REDIS_TEST and have a redis server running locally.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 basin==0.1
 boto==2.30.0
-pilbox==1.0.3
+https://pypi.python.org/packages/source/p/pilbox/pilbox-1.0.3.tar.gz#md5=514a99f784a4c06242144a005322fe52#egg=pilbox

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     # setuptools wants source code. Check PyPi to see if fixed...
     dependency_links = [
             'https://pypi.python.org/packages/source/p/pilbox/pilbox-1.0.3.tar.gz#md5=514a99f784a4c06242144a005322fe52#egg=pilbox', 
+            'https://github.com/mredar/redis-collections/archive/master.zip#egg=redis-collections',
             ],
     install_requires=['boto', 'basin', 'pilbox', 'python-magic'],
     url='https://github.com/tingletech/md5s3stash',
@@ -35,5 +36,5 @@ setup(
         ]
     },
     test_suite='tests',
-    tests_require=['mock',],
+    tests_require=['mock', 'unittest2', 'redis_collections', 'HTTPretty']
 )


### PR DESCRIPTION
Added tests to check that headers are sent when the url is found in the url cache (using HTTPretty to intercept the request).

Added a test that uses redis-collections to test using a redis-tied dictionary implementation as the cache.
This requires a locally running redis server, easiest to use the docker official redis image.
docker pull redis
docker run -p 6379:6379 --name md5-test -d redis